### PR TITLE
Add tvOS prefix for libraries used for tvos

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,9 @@ let package = Package(
     ],
     products: [
         // Define separate products for each target to keep them isolated
-        .library(name: "AVPlayer-GoogleAds", targets: ["s2s_sdk_tvos_avplayer_googleAds"]),
-        .library(name: "Bitmovin", targets: ["s2s_sdk_tvos_bitmovin"]),
-        .library(name: "AgentOnly", targets: ["s2s_sdk_tvos_agent_only"])
+        .library(name: "tvOSAVPlayer-GoogleAds", targets: ["s2s_sdk_tvos_avplayer_googleAds"]),
+        .library(name: "tvOSBitmovin", targets: ["s2s_sdk_tvos_bitmovin"]),
+        .library(name: "tvOSAgentOnly", targets: ["s2s_sdk_tvos_agent_only"])
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
# Fix Conflict with Same-Named Libraries for iOS and tvOS

## Issue  
We encountered issues with libraries having the same name for both iOS and tvOS. Since our codebase is shared between iOS and tvOS, conflicts arise when a library has an identical name in both platforms.

## Solution  
To resolve this, I have forked your library specifically for tvOS and added a **`tvOS`** prefix to the library name. This ensures that both versions can coexist without naming conflicts.

## Changes  
- Forked the existing library for tvOS.  
- Renamed the tvOS-specific library with a `tvOS` prefix.  
- Updated references to the tvOS library accordingly.  

## Impact  
This change allows our iOS and tvOS projects to use the same libraries without encountering naming conflicts.

## Request  
Please review and merge this PR to support a seamless integration for projects using both iOS and tvOS.

Let me know if you have any concerns. Thanks! 🚀  
<img width="1291" alt="Screenshot 2025-02-10 at 2 42 48 PM" src="https://github.com/user-attachments/assets/80098122-9fcf-4493-a24b-fbb361bb518d" />


